### PR TITLE
Renamed `struct request` in kinect2.c:55:8 to `struct requestPacket`

### DIFF
--- a/kinect2.c
+++ b/kinect2.c
@@ -52,7 +52,7 @@ static const u32 start_cmd = 0x01;
 static const u32 stop_cmd  = 0x00;
 
 /* request packet for kinect2 sensor */
-struct request {
+struct requestPacket {
 	u32 magic;
 	u32 cmdseq;
 	u32 reply_len;
@@ -65,10 +65,10 @@ struct request {
 struct sd {
 	struct gspca_dev gspca_dev; /* !! must be the first item */
 
-	u32 cmdseq;              /* a sequence number for control commands */
-	struct request request;  /* a buffer for sending control commands */
-	u32 response[32];        /* a buffer for receiving response */
-	u8  synced;              /* a flag for sd_depth_pkt_scan() */
+	u32 cmdseq;              	/* a sequence number for control commands */
+	struct requestPacket request;	/* a buffer for sending control commands */
+	u32 response[32];        	/* a buffer for receiving response */
+	u8  synced;              	/* a flag for sd_depth_pkt_scan() */
 
 	struct v4l2_ioctl_ops ioctl_ops;
 };
@@ -115,7 +115,7 @@ static int send_cmd(struct gspca_dev *gspca_dev, u32 cmd,
 {
 	struct sd *sd = (struct sd *) gspca_dev;
 	struct usb_device *udev = gspca_dev->dev;
-	struct request *req = &sd->request;
+	struct requestPacket *req = &sd->request;
 	int actual_len, result = 0;
 	int res, i;
 


### PR DESCRIPTION
In `include/linux/blkdev.h:118:8` there is already a definition of `struct request` which causes the compilation error of "redefination struct request". Renaming variable to a more verbose name fixes the issue. No other logic changes needed to fix this particular compilation issue.